### PR TITLE
Update the link to fortio.org

### DIFF
--- a/_includes/how-to-choose.html
+++ b/_includes/how-to-choose.html
@@ -21,7 +21,7 @@
         <li>Test the latency and resource overhead for your individual application. 
           For each service mesh candidates, set up an identical test environment and install the service mesh. 
           Set up an additional mesh-free environment. Install your application in all environments.
-          Perform a load test in all and measure request latency, CPU and memory consumption by using tools like <a href="https://locust.io" target="_blank">Locust</a> or <a href="https://https://fortio.org" target="_blank">Fortio</a>.</li
+          Perform a load test in all and measure request latency, CPU and memory consumption by using tools like <a href="https://locust.io" target="_blank">Locust</a> or <a href="https://fortio.org/" target="_blank">Fortio</a>.</li
     </ul>
   </p>
 </div>


### PR DESCRIPTION
The link to fortio.org was directing to https://https//fortio.org