### PR TITLE
Remove Consul drawback

### DIFF
--- a/_includes/comparison.html
+++ b/_includes/comparison.html
@@ -117,7 +117,7 @@
             <td>Istio's flexibility can be overwhelming for teams who don't have the capacity for more complex technology. Also, Istio takes control of the ingress controller.</td>
             <td>Linkerd 2 is deeply integrated with Kubernetes and cannot be expanded. Since Linkerd 2 does not rely on a third-party proxy, it cannot be extended easily.</td>
             <td>AWS App Mesh configuration cannot be migrated to an environment outside AWS.</td>
-            <td>Consul Connect can only be used in combination with Consul.</td>
+            <td></td>
             <td>Maesh currently does not support transparent TLS encryption.</td>
             <td>Kuma is still in an early state. That might be a risk for production.</td>
           </tr>


### PR DESCRIPTION
I am proposing this change because I am not entirely clear as to what this drawback may be referring to.

Consul is platform agnostic and works across a wide range infrastructure platforms/cloud environments. It can be used in physical, VM, or container-based environments such as Kubernetes. It is not limited to a particular infrastructure platform.

In that context I'm not sure it makes sense to keep this drawback. I'm happy to discuss if you disagree, or if this is referring to something else.