### PR TITLE
Re-add compatible tracing backends for Consul

### DIFF
--- a/_includes/comparison.html
+++ b/_includes/comparison.html
@@ -298,7 +298,7 @@
         <td><a href="https://www.jaegertracing.io" target="_blank">Jaeger</a>, <a href="https://zipkin.io" target="_blank">Zipkin</a>, <a href="http://www.solarwinds.com" target="_blank">Solarwinds</a></td>
         <td>all Backends supporting <a href="https://opencensus.io/service/exporters" target="_blank">OpenCensus</a></td>
         <td><a href="http://aws.amazon.com/xray/" target="_blank">AWS X-Ray</a></td>
-        <td></td>
+        <td><a href="https://www.datadoghq.com" target="_blank">Datadog</a>, <a href="https://www.jaegertracing.io" target="_blank">Jaeger</a>, <a href="https://zipkin.io" target="_blank">Zipkin</a>, <a href="https://opentracing.io" target="_blank">OpenTracing</a>, <a href="https://www.honeycomb.io" target="_blank">Honeycomb</a></td>
         <td><a href="https://www.jaegertracing.io" target="_blank">Jaeger</a></td>
         <td>all Backends supporting <a href="https://opentracing.io" target="_blank">OpenTracing</a></td>
       </tr>


### PR DESCRIPTION
Erroneously removed in commit f6ca7e4.