### PR TITLE
Jaeger is integrated in Linkerd

### DIFF
--- a/_includes/comparison.html
+++ b/_includes/comparison.html
@@ -305,7 +305,7 @@
       <tr>
         <th scope="row">Integrated, pre-configured Tracing-Backends</th>
         <td>yes, <a href="https://istio.io/docs/tasks/observability/distributed-tracing/jaeger/" target="_blank">Jaeger</a> or <a href="https://istio.io/docs/tasks/observability/distributed-tracing/zipkin/" target="_blank">Zipkin</a> for nonprod environments</td>
-        <td><a href="https://linkerd.io/2/tasks/distributed-tracing/" target="_blank">no</a></td>
+        <td>yes, <a href="https://linkerd.io/2/tasks/distributed-tracing/" target="_blank">Jaeger</a></td>
         <td><a href="https://docs.aws.amazon.com/xray/latest/devguide/xray-services-appmesh.html" target="_blank">yes, AWS X-Ray</a></td>
         <td><a href="https://github.com/hashicorp/consul-demo-tracing" target="_blank">no</a></td>
         <td><a href="https://github.com/containous/maesh/pull/79" target="_blank">yes, Jaeger</a></td>


### PR DESCRIPTION
IMHO Jaeger is integrated in Linkerd. The linked tasks explains how to install that extension. That is not unlike what Istio offers. However, the link was already there so I am not sure whether there is something I don't understand.