### PR TITLE
Remove Connect feature name from Consul

### DIFF
--- a/_includes/comparison.html
+++ b/_includes/comparison.html
@@ -7,7 +7,7 @@
         <th class="table-head" scope="col">Istio</th>
         <th class="table-head" scope="col">Linkerd 2</th>
         <th class="table-head" scope="col">AWS App Mesh</th>
-        <th class="table-head" scope="col">Consul Connect</th>
+        <th class="table-head" scope="col">Consul</th>
         <th class="table-head" scope="col">Traefik Mesh (formerly Maesh)</th>
         <th class="table-head" scope="col">Kuma</th>
         <th class="table-head" scope="col">Open Service Mesh (OSM)</th>
@@ -99,7 +99,7 @@
             <td>Istio can be adapted and extended like no other Mesh. Its many features are available for Kubernetes and other platforms.</a></td>
             <td>Linkerd 2 is designed to be non-invasive and is optimized for performance and usability. Therefore, it requires little time to adopt.</td>
             <td>AWS App Mesh is integrated into the AWS landscape and it is fully managed for you.</td>
-            <td>Consul Connect can be used in any Consul environment and therefore does not require a scheduler. The proxy can be changed and extended.</td>
+            <td>Consul service mesh can be used in any Consul environment and therefore does not require a scheduler. The proxy can be changed and extended.</td>
             <td>Traefik Mesh focuses on a selection of features to achieve good usability and performance.</td>
             <td>Kuma supports both Kubernetes and VMs - including hybrid multi-zone deployments - and allows you to customize the Envoy Proxy.</td>
             <td></td>
@@ -109,7 +109,7 @@
             <td>Istio's flexibility can be overwhelming for teams who don't have the capacity for more complex technology. Also, Istio takes control of the ingress controller.</td>
             <td>Linkerd 2 is deeply integrated with Kubernetes and cannot be expanded. Since Linkerd 2 does not rely on a third-party proxy, it cannot be extended easily.</td>
             <td>AWS App Mesh configuration cannot be migrated to an environment outside AWS.</td>
-            <td>Consul Connect can only be used in combination with Consul.</td>
+            <td>Consul service mesh can only be used in combination with Consul.</td>
             <td>Traefik Mesh currently does not support transparent TLS encryption.</td>
             <td>Kuma is still in an early state. That might be a risk for production.</td>
             <td></td>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,17 +19,17 @@
   <meta name="date" content="{{ site.time | date: '%Y-%m-%d' }}" scheme="YYYY-MM-DD">
 
   <meta name="title" content="servicemesh.es | Service Mesh Comparison">
-  <meta name="description" content="Service Mesh Feature Comparison — including Istio, Linkerd 2, AWS App Mesh, Consul Connect, Maesh, Kuma, Open Service Mesh (OSM)">
+  <meta name="description" content="Service Mesh Feature Comparison — including Istio, Linkerd 2, AWS App Mesh, Consul, Maesh, Kuma, Open Service Mesh (OSM)">
 
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:site" content="@INNOQ">
   <meta name="twitter:creator" content="@INNOQ">
   <meta name="twitter:title" content="{{ site.title }}">
-  <meta name="twitter:description" content="Service Mesh Feature Comparison — including Istio, Linkerd 2, AWS App Mesh, Consul Connect, Maesh, Kuma, Open Service Mesh (OSM)">
+  <meta name="twitter:description" content="Service Mesh Feature Comparison — including Istio, Linkerd 2, AWS App Mesh, Consul, Maesh, Kuma, Open Service Mesh (OSM)">
   <meta name="twitter:image" content="https://servicemesh.es/img/table_preview.png?v=BGmQMWez4Q">
 
   <meta property="og:title" content="{{ site.title }}">
-  <meta property="og:description" content="Service Mesh Feature Comparison — including Istio, Linkerd 2, AWS App Mesh, Consul Connect, Maesh, Kuma, Open Service Mesh (OSM)">
+  <meta property="og:description" content="Service Mesh Feature Comparison — including Istio, Linkerd 2, AWS App Mesh, Consul, Maesh, Kuma, Open Service Mesh (OSM)">
   <meta property="og:image" content="https://servicemesh.es/img/table_preview.png?v=BGmQMWez4Q">
   <meta property="og:url" content="https://servicemesh.es/">
   

--- a/_includes/implementations.html
+++ b/_includes/implementations.html
@@ -36,7 +36,7 @@
               <span class="helper"></span> 
               <img src="img/consul.png"/ class="img-center" style="max-height: 110px" height="75px">
             </div>
-          <h2 class="list-teaser__headline">Consul/Consul Connect</h2>
+          <h2 class="list-teaser__headline">Consul</h2>
           <p class="list-teaser__text">
             HashiCorp's Consul has been well known as a service discovery solution for a long time. Now that it has adopted the Envoy proxy and Sidecar pattern, Consul can serve as a service mesh for a variety of platforms like Kubernetes and VMs.
           </p>


### PR DESCRIPTION
Remove 'connect' name from Consul. Connect is a feature of Consul, and not a separate project. Dropping the name to avoid confusion.