### PR TITLE
Update Consul drawback

### DIFF
--- a/_includes/comparison.html
+++ b/_includes/comparison.html
@@ -109,7 +109,7 @@
             <td>Istio's flexibility can be overwhelming for teams who don't have the capacity for more complex technology. Also, Istio takes control of the ingress controller.</td>
             <td>Linkerd is deeply integrated with Kubernetes and does not currently support non-Kubernetes workloads. It also does not currently support data plane extensions.</td>
             <td>AWS App Mesh configuration cannot be migrated to an environment outside AWS.</td>
-            <td>Consul service mesh can only be used in combination with Consul.</td>
+            <td>Consul uses its own internal storage, and does not on rely Kubernetes for persistent storage.</td>
             <td>Traefik Mesh currently does not support transparent TLS encryption.</td>
             <td>Kuma is possibly the most flexible service mesh. Teams should thoroughly consider whether their project can handle the complexity involved.</td>
             <td>OpenServiceMesh (OSM) is the latest service mesh Implementation and simply too young to be production-ready.</td>


### PR DESCRIPTION
Followup from #22. Change Consul drawback to state that Consul does not rely on K8s for persistent storage.

Other feedback from #22 is no longer accurate, such as Consul using a separate service registry. As of recent releases, Consul uses and extends service registry information it obtains from Kubernetes.