### PR TITLE
docs: Kuma traffic splitting updated to latest version

### DIFF
--- a/_includes/comparison.html
+++ b/_includes/comparison.html
@@ -21,7 +21,7 @@
         <td></td>
         <td>1.10</td>
         <td>1.4</td>
-        <td>1.1</td>
+        <td>1.2.3</td>
         <td>0.8</td>
       </tr>
       <tr>
@@ -403,7 +403,7 @@
         <td><a href="https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_CreateRoute.html" target="_blank">yes</a> </td> 
         <td><a href="https://www.consul.io/docs/agent/config-entries/service-router" target="_blank">yes</a></td>
         <td>no</td>
-        <td>no*</td>
+        <td><a href="https://kuma.io/docs/latest/policies/traffic-route/#l7-traffic-split" target="_blank">yes</a>, with transformations</td>
         <td>Header-based via <a href="https://github.com/servicemeshinterface/smi-spec/blob/master/apis/traffic-split/v1alpha3/traffic-split.md" target="_blank">SMI</a></td>
       </tr>
     </tbody>


### PR DESCRIPTION
Updating Kuma to the latest version, including L7 traffic splitting and transformations.