### PR TITLE
Remove tech preview label for Consul on ECS

### DIFF
--- a/_includes/comparison.html
+++ b/_includes/comparison.html
@@ -200,7 +200,7 @@
         <td>Kubernetes</td>
         <td>Kubernetes</td>
         <td>ECS, Fargate, EKS, EC2</td>
-        <td>ECS (tech preview), Kubernetes, Nomad, VMs</td>
+        <td>ECS, Kubernetes, Nomad, VMs</td>
         <td>Kubernetes</td>
         <td>Kubernetes, VMs</td>
         <td>Kubernetes</td>


### PR DESCRIPTION
Consul now officially supports AWS ECS as a target platform. Remove the tech preview label for ECS platform support.

See <https://www.hashicorp.com/blog/consul-service-mesh-on-amazon-ecs-now-generally-available>.