### PR TITLE
Consul: add CNI Plugin

### DIFF
--- a/_includes/comparison.html
+++ b/_includes/comparison.html
@@ -183,7 +183,7 @@
         <td><a href="https://istio.io/latest/docs/setup/additional-setup/cni/" target="_blank">yes</a>, in beta</td>
         <td><a href="https://linkerd.io/2/features/cni/" target="_blank">yes</a></td>
         <td><a href="https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ProxyConfiguration.html" target="_blank">yes</a></td>
-        <td>no</td>
+        <td><a href="https://www.consul.io/docs/k8s/installation/install#enable-the-consul-cni-plugin" target="_blank">yes</a></td>
         <td>no</td>
         <td><a href="https://kuma.io/docs/latest/documentation/networking/#transparent-proxying" target="_blank">yes</a></td>
         <td><a href="https://github.com/openservicemesh/osm/issues/1610" target="_blank">no</a></td>


### PR DESCRIPTION
As of Consul 1.13, Consul now includes a CNI Plugin for Transparent Proxy: https://www.consul.io/docs/k8s/installation/install#enable-the-consul-cni-plugin 