### PR TITLE
Update Consul version to 1.13

### DIFF
--- a/_includes/comparison.html
+++ b/_includes/comparison.html
@@ -19,7 +19,7 @@
         <td>1.13</td>
         <td>2.11</td>
         <td></td>
-        <td>1.12</td>
+        <td>1.13</td>
         <td>1.4</td>
         <td>1.7</td>
         <td>1.0</td>
@@ -210,7 +210,7 @@
         <td><a href="https://cloud.google.com/istio" target="_blank">Google Cloud</a>, <a href="https://www.alibabacloud.com/help/doc-detail/89805.htm" target="_blank">Alibaba Cloud</a>, <a href="https://cloud.ibm.com/docs/containers?topic=containers-istio" target="_blank">IBM Cloud</a></td>
         <td><a href="https://marketplace.digitalocean.com/apps/linkerd" target="_blank">DigitalOcean</a></td>
         <td><a href="https://aws.amazon.com/app-mesh/" target="_blank">AWS</a></td>
-        <td><a href="https://cloud.hashicorp.com/products/consul" target="_blank">HCP Consul on AWS</a>, <a href="https://www.hashicorp.com/products/consul/service-on-azure/" target="_blank">Microsoft Azure</a></td>
+        <td><a href="https://cloud.hashicorp.com/products/consul" target="_blank">HCP Consul on AWS and Azure</a></td>
         <td></td>
         <td></td>
         <td><a href="https://docs.microsoft.com/en-us/azure/aks/servicemesh-osm-about" target="_blank">Microsoft Azure</a></td>
@@ -220,7 +220,7 @@
         <td><a href="https://istio.io/latest/docs/setup/install/virtual-machine/" target="_blank">yes</a></td>
         <td>no</td>
         <td>yes, within AWS</td>
-        <td><a href="https://www.consul.io/docs/k8s/installation/multi-cluster/vms-and-kubernetes" target="_blank">yes</a></td>
+        <td><a href="https://www.consul.io/docs/k8s/deployment-configurations/multi-cluster/vms-and-kubernetes" target="_blank">yes</a></td>
         <td>no</td>
         <td><a href="https://kuma.io/docs/latest/deployments/multi-zone" target="_blank">yes</a></td>
         <td>no</td>
@@ -230,7 +230,7 @@
         <td><a href="https://istio.io/docs/setup/install/multicluster/" target="_blank">yes</a></td>
         <td><a href="https://linkerd.io/2/features/multicluster/" target="_blank">yes</a></td>
         <td></td>
-        <td><a href="https://www.consul.io/docs/k8s/installation/multi-cluster" target="_blank">yes</a></td>
+        <td><a href="https://www.consul.io/docs/k8s/deployment-configurations/multi-cluster" target="_blank">yes</a></td>
         <td>no</td>
         <td><a href="https://kuma.io/docs/latest/deployments/multi-zone" target="_blank">yes</a></td>
         <td><a href="https://github.com/openservicemesh/osm/issues/3456" target="_blank">planned</a></td>


### PR DESCRIPTION
This commit updates the Consul version to 1.13.

It also changes a few Consul links so they point to the correct locations on HashiCorp's web properties.