### PR TITLE
Consul 1.15 updates

### DIFF
--- a/_includes/comparison.html
+++ b/_includes/comparison.html
@@ -20,7 +20,7 @@
         <td>1.13</td>
         <td>2.11</td>
         <td></td>
-        <td>1.14</td>
+        <td>1.15</td>
         <td>1.4</td>
         <td>2.0</td>
         <td>1.0</td>
@@ -330,7 +330,7 @@
         <td><a href="https://istio.io/docs/tasks/observability/logs/collecting-logs/" target="_blank">yes</a></td>
         <td>no (<a href="https://linkerd.io/2/reference/cli/tap/" target="_blank">tap feature</a> instead)</td>
         <td><a href="https://docs.aws.amazon.com/app-mesh/latest/userguide/envoy-logs.html">yes</a></a></td>
-        <td>yes</td>
+        <td>><a href="https://developer.hashicorp.com/consul/docs/connect/observability/access-logs" target="_blank">yes</a></td>
         <td>yes</td>
         <td><a href="https://kuma.io/docs/latest/policies/traffic-log/#traffic-log" target="_blank">yes</a></td>
         <td>no</td>


### PR DESCRIPTION
- Bump to Consul 1.15
- Link to new Access Logs documentation overview, which provides centralized access logs for Consul. 